### PR TITLE
fix: Redmine 5 compatibility and code cleanup

### DIFF
--- a/app/controllers/tab_controller.rb
+++ b/app/controllers/tab_controller.rb
@@ -1,17 +1,17 @@
 # tab_controller.rb
-#  
+#
 # Copyright (C) 2008-2009  James Turnbull <james@lovedthanlost.net>
-# 
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
@@ -19,11 +19,11 @@
 
 class TabController < ApplicationController
   unloadable
-  
+
   layout 'base'
-  
-  before_filter :find_project, :authorize, :only => [:show]
-  
+
+  before_action :find_project, :authorize, :only => [:show]
+
   def show
     @tab_text = Tab.get_tab_text(@project)
   end
@@ -32,9 +32,9 @@ class TabController < ApplicationController
     @tab_text = Setting.plugin_redmine_tab['system_tab_text']
     render :action => 'show'
   end
-  
+
   private
-  
+
   def find_project
   # @project variable must be set before calling the authorize filter
     @project = Project.find(params[:id])

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,0 +1,5 @@
+pt:
+  tab_text_project_specific: Projeto específico
+  tab_text_systemwide: Todo Sistema
+  tab_label_tab_name: Nome da Aba
+  tab_label_tab_text: Texto da Aba

--- a/init.rb
+++ b/init.rb
@@ -5,12 +5,12 @@
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2
 # of the License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -21,9 +21,13 @@ Rails.logger.info 'Starting Tab plugin for Redmine'
 
 Redmine::Plugin.register :redmine_tab do
   name 'Tab Plugin'
-  author 'James Turnbull'
-  description 'A plugin which adds Redmine tabs to embed content from an iframe on a per-project and system-wide base.'
-  version '0.4.0'
+  author 'James Turnbull (orig)'
+  author_url 'https://github.com/tools-aoeur'
+  description 'Adds Redmine tabs to embed content from an iframe on a per-project and system-wide base.'
+  url 'https://github.com/tools-aoeur/redmine_tab.git'
+  version '1.0.0'
+
+  requires_redmine version_or_higher: '5.0'
 
   settings :default => {
     'tab_text' => '',
@@ -46,8 +50,6 @@ Redmine::Plugin.register :redmine_tab do
     string = Setting.plugin_redmine_tab[setting_name]
     if !string.blank? && string.match(/\A:/) # uses symbol syntax, :string
       string.gsub!(':','')
-      string = GLoc.l(string.to_sym) if Object.const_defined?('GLoc') # Rails 2.1.x
-      string = I18n.t(string.to_sym) if Object.const_defined?('I18n') # Rails 2.2.x
     end
     string
   }

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,5 +1,0 @@
-tab_text_project_specific: Project Specific
-tab_text_systemwide: System wide
-tab_label_tab_name: Tab Name
-tab_label_tab_text: Tab Text
-

--- a/lang/ja.yml
+++ b/lang/ja.yml
@@ -1,4 +1,0 @@
-tab_text_project_specific: "プロジェクト個別"
-tab_text_systemwide: "システム全体"
-tab_label_tab_name: "タブ名"
-tab_label_tab_text: "タブ テキスト"

--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -1,5 +1,0 @@
-tab_text_project_specific: Project Specifiek
-tab_text_systemwide: Globaal
-tab_label_tab_name: Tab Naam
-tab_label_tab_text: Tab Bron
-

--- a/lang/pt.yml
+++ b/lang/pt.yml
@@ -1,4 +1,0 @@
-tab_text_project_specific: Projeto específico
-tab_text_systemwide: Todo Sistema
-tab_label_tab_name: Nome da Aba
-tab_label_tab_text: Texto da Aba


### PR DESCRIPTION
* Set the required redmine version to minimum 5.0
* `before_filter` -> `before_action`
* Got rid of the old translation files, moved and adapted Portuguese translation
* rails 2.x support dropped entirely, removed from code